### PR TITLE
Tweaked physical damage calculation

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -199,9 +199,9 @@ var calculator = (function() {
 	    
 		var as = scenario.attackerStats; var ds = scenario.defenderStats; var skillPower = scenario.skillPower;
 
-        var totalAttack = as.attack + as.weapon;
+        var totalAttack = min(as.attack + as.weapon, 255);
         
-        var initDamage = (skillPower / 16) * (totalAttack + (((as.level + totalAttack) / 32) * ((as.level * totalAttack) / 32)));
+        var initDamage = (1 / 16) * (totalAttack + (((as.level + totalAttack) / 32) * ((as.level * totalAttack) / 32)));
 		combinedPower = skillPower * (512 - ds.defence) * initDamage;
 			
 		baseDamage = combinedPower / (16 * 512);


### PR DESCRIPTION
Fixed two issues with physical damage: 1) totalAttack should be capped to 255, and 2) skillPower was erroneously appearing quadratically.