### PR TITLE
Update ui.js

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -54,8 +54,8 @@ for (var i = 0; i < inputs.length; i++) {
             this.value = this.defaultValue;
         }
 
-        else if (this.value > 255) {
-            this.value = 255;
+        else if (this.value > 511) {
+            this.value = 511;
         }
     }
 }


### PR DESCRIPTION
This allows to enter numbers greater than 255 in the calculator. 

Reason:
Magic Defense can be higher than 255. Examples: Demon's Gate has a magic defense of 450 and Materia Keeper has a Magic Defense of 280. Ruby weapon boasts a whopping 500 magic defense and is - to my knowledge - the enemy with the highest magic defense in the game.

Possible further improvements:
Allowing values depending on the type of input field, e. g. magic defense, character level, magic stat, etc...